### PR TITLE
Auth_wrapper changes to handle errors

### DIFF
--- a/lib/google/auth_wrapper.rb
+++ b/lib/google/auth_wrapper.rb
@@ -7,23 +7,37 @@ module Google
     #
     # @return [Google::Auth::UserRefreshCredentials] OAuth2 credentials
     def self.authorize(credentials_path:, token_path:, scope:)
-      client_id = Google::Auth::ClientId.from_file credentials_path
-      token_store = Google::Auth::Stores::FileTokenStore.new file: token_path
-      authorizer = Google::Auth::UserAuthorizer.new client_id, scope, token_store
-      credentials = authorizer.get_credentials user_id
-      if credentials.nil?
-        url = authorizer.get_authorization_url base_url: oob_uri
-        puts "Open the following URL in the browser and enter the " \
-             "resulting code after authorization:\n" + url
-        code = gets
-        credentials = authorizer.get_and_store_credentials_from_code(
-          user_id: user_id, code: code, base_url: oob_uri
-        )
+      begin
+        client_id = Google::Auth::ClientId.from_file credentials_path
+        token_store = Google::Auth::Stores::FileTokenStore.new file: token_path
+        authorizer = Google::Auth::UserAuthorizer.new client_id, scope, token_store
+        credentials = authorizer.get_credentials user_id
+        if credentials.nil?
+          puts "⛔  No credentials error - please authorize  ⛔"
+          credentials = re_authorize(authorizer: authorizer)
+        end
+      rescue Signet::AuthorizationError
+        puts "⛔  Authorization failed - requesting re-authorization  ⛔"
+        credentials = re_authorize(authorizer: authorizer)
+      rescue
+        puts "⛔  Unknown error - requesting re-authorization  ⛔"
+        credentials = re_authorize(authorizer: authorizer)
       end
+      puts "🔑︎  Generated credentials  🔑︎"
       credentials
     end
 
     private
+
+    def self.re_authorize(authorizer:)
+      url = authorizer.get_authorization_url base_url: oob_uri
+      puts "Open the following URL in the browser and enter the " \
+            "resulting code after authorization:\n" + url
+      code = gets
+      authorizer.get_and_store_credentials_from_code(
+        user_id: user_id, code: code, base_url: oob_uri
+      )
+    end
 
     def self.oob_uri
       "urn:ietf:wg:oauth:2.0:oob".freeze


### PR DESCRIPTION
 - Added rescue clauses to the Google::AuthWrapper authorize method to handle Token timeouts and misc errors
 - Separated out re-authorization into the private re_authorize(authorizer:) method
 - Added some eye candy

Fixes #11 